### PR TITLE
fix(earn): if no data is presented don't show table on desktop size; split backend finished contracts requests due to possible 404 error

### DIFF
--- a/src/pages/Earn/Earn.tsx
+++ b/src/pages/Earn/Earn.tsx
@@ -40,13 +40,20 @@ export const Earn: FC = () => {
         </Grid>
 
         <Grid item xs={12}>
-          <EarnTable
-            className={classes.tableContainer}
-          />
+          {
+            hasTableData && (
+              <EarnTable
+                className={classes.tableContainer}
+              />
+            )
+          }
+          {
+            !hasTableData && <EmptyTableBlock />
+          }
 
           <Box className={classes.mobileTableData}>
             {
-              hasTableData ? (
+              hasTableData && (
                 finishedContracts.map((item, rowIndex) => {
                   const rowKey = JSON.stringify(item) + rowIndex;
                   const { deserializedRewardAmount } = getRowItemData(item);
@@ -59,8 +66,6 @@ export const Earn: FC = () => {
                     />
                   );
                 })
-              ) : (
-                <EmptyTableBlock />
               )
             }
           </Box>

--- a/src/store/earn/sagas/getFinishedContracts.ts
+++ b/src/store/earn/sagas/getFinishedContracts.ts
@@ -7,7 +7,12 @@ import { AxiosResponse } from 'axios';
 import apiActions from 'store/ui/actions';
 import userSelector from 'store/user/selectors';
 import { baseApi } from 'store/api/apiRequestBuilder';
-import { IGetFinishedLostKeyContractsReturnType, IGetFinishedWillContractsReturnType } from 'store/api/apiRequestBuilder.types';
+import {
+  IFinishedLostKeyContract,
+  IFinishedWillContract,
+  IGetFinishedLostKeyContractsReturnType,
+  IGetFinishedWillContractsReturnType,
+} from 'store/api/apiRequestBuilder.types';
 import { contractsHelper } from 'utils';
 import { ContractsNames, TFinishedContract, UserState } from 'types';
 import actionTypes from '../actionTypes';
@@ -55,18 +60,38 @@ function* extendFinishedContractsWithRewardAmount(
   }
 }
 
-function* fetchAndTransformFinishedContracts(provider: Web3) {
+function* fetchFinishedWillContracts() {
   try {
     const {
       data: { lastwills },
     }: AxiosResponse<IGetFinishedWillContractsReturnType> = yield call(
       baseApi.getFinishedWillContracts,
     );
+    return lastwills;
+  } catch (err) {
+    console.log(err);
+    return [];
+  }
+}
+
+function* fetchFinishedLostKeyContracts() {
+  try {
     const {
       data: { lostkeys },
     }: AxiosResponse<IGetFinishedLostKeyContractsReturnType> = yield call(
       baseApi.getFinishedLostKeyContracts,
     );
+    return lostkeys;
+  } catch (err) {
+    console.log(err);
+    return [];
+  }
+}
+
+function* fetchAndTransformFinishedContracts(provider: Web3) {
+  try {
+    const lastwills: IFinishedWillContract[] = yield call(fetchFinishedWillContracts);
+    const lostkeys: IFinishedLostKeyContract[] = yield call(fetchFinishedLostKeyContracts);
     const finishedContracts = [
       ...lastwills,
       ...lostkeys,


### PR DESCRIPTION
### Earn Page
* cb-166 (if no data is presented -> don't show table on desktop window size)
* split backend finished contracts requests due to possible 404 error
![image](https://user-images.githubusercontent.com/33129671/158491165-040be804-bfeb-4e9d-9233-7294e4b4e94f.png)
if anything in the try/catch block will throw an error (that was thrown from 'lastwill_finished/' due to possible 404 eror) then it will be rejected EVEN if 'lostkey_finished/' returns something